### PR TITLE
Fix a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
                                     <a href="https://github.com/Igalia/css-grid-layout/blob/gh-pages/demo-alignment.png" class="label label-info">screenshot</a>
                                     <a href="http://dev.w3.org/csswg/css-grid/#alignment" class="label label-warning">spec</a>
                                 </p>
-                                <p>Another alighment demo, this time it changes the value of <code>justify-self</code> and <code>align-self</code> properties of the items in each track (column/row).</p>
+                                <p>Another alignment demo, this time it changes the value of <code>justify-self</code> and <code>align-self</code> properties of the items in each track (column/row).</p>
                             </li>
                             <li class="list-group-item">
                                 <h4 class="list-group-item-heading">Calendar demo</h4>


### PR DESCRIPTION
`alighment` → `alignment`
